### PR TITLE
ImageJ BioFormats import/export wrapper for Zeiss CZI added

### DIFF
--- a/BioFormatsSplit/Makefile
+++ b/BioFormatsSplit/Makefile
@@ -1,0 +1,21 @@
+##
+## Produce a binary executable from the Matlab code in this
+## directory.
+##
+
+SOURCES	= imagej-bioformats imagej-bioformats-vncstartup
+
+default: dummy
+
+-include ../Makefile.inc
+
+dummy:
+
+clean::
+
+install: $(BINDIR) $(patsubst %,$(BINDIR)/%,$(SOURCES))
+
+$(BINDIR)/%: %
+	install $< $@
+
+-include ../Makefile.rules.post

--- a/BioFormatsSplit/imagej-bioformats
+++ b/BioFormatsSplit/imagej-bioformats
@@ -1,0 +1,105 @@
+#!/bin/bash
+#
+# Execute a ImageJ BioFormats macro in a VNC session -- BioFormats
+# requires a GUI to be available.
+#
+
+IMAGEJ_MACRO_FILE=""
+IMAGEJ_MACRO_DATADIR=""
+IMAGEJ_MACRO_LOGFILE=""
+
+VNCSTARTUP_FILE="$(which imagej-bioformats-vncstartup 2>/dev/null)"
+if [ $? -ne 0 ]; then
+    if [ -x "./imagej-bioformats-vncstartup" ]; then
+        VNCSTARTUP_FILE="./imagej-bioformats-vncstartup"
+    else
+        echo "ERROR:  unable to locate 'imagej-bioformats-vncstartup' script" 1>&2
+        exit 1
+    fi
+fi
+
+help() {
+    cat <<EOT
+usage:
+
+    $0 {options}
+
+  options:
+
+    -h/--help                     display program help screen
+    -m/--macro <file>             the IJM macro file to execute
+    -d/--data <directory>         path to the data directory for the macro
+                                  (e.g. where CZI images are located)
+    -l/--log <file>               write output from the IJM macro execution
+                                  to this file; overwrites any previous
+                                  content in the file, by default output
+                                  goes to the VNC session log file
+
+EOT
+    exit 0
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+
+        -h|--help)
+            help
+            ;;
+
+        -m|--macro)
+            shift
+            if [ -z "$1" ]; then
+                echo "ERROR:  no filename provided with -m/--macro" 1>&2
+                exit 11
+            fi
+            IMAGEJ_MACRO_FILE="$1"
+            ;;
+        --macro=*)
+            IMAGEJ_MACRO_FILE="$(echo "$1" | sed 's/^--macro=//')"
+            ;;
+
+        -d|--data)
+            shift
+            if [ -z "$1" ]; then
+                echo "ERROR:  no filename provided with -d/--data" 1>&2
+                exit 11
+            fi
+            IMAGEJ_MACRO_DATADIR="$1"
+            ;;
+        --data=*)
+            IMAGEJ_MACRO_DATADIR="$(echo "$1" | sed 's/^--data=//')"
+            ;;
+
+        -l|--log)
+            shift
+            if [ -z "$1" ]; then
+                echo "ERROR:  no filename provided with -l/--log" 1>&2
+                exit 11
+            fi
+            IMAGEJ_MACRO_LOGFILE="$1"
+            ;;
+        --log=*)
+            IMAGEJ_MACRO_LOGFILE="$(echo "$1" | sed 's/^--log=//')"
+            ;;
+
+        *)
+            echo "ERROR:  unknown command line flag: $1" 1>&2
+            exit 11
+            ;;
+
+    esac
+    shift
+done
+
+# Vet all of the arguments:
+if [ -z "$IMAGEJ_MACRO_FILE" ]; then
+    echo "ERROR:  no macro file provided" 1>&2
+    exit 11
+fi
+
+# Export our control variables so the VNC startup script will see them:
+export IMAGEJ_MACRO_FILE IMAGEJ_MACRO_DATADIR IMAGEJ_MACRO_LOGFILE
+
+# Launch the VNC-wrapped run:
+exec vncserver -fg -autokill -xstartup "$VNCSTARTUP_FILE"
+

--- a/BioFormatsSplit/imagej-bioformats-vncstartup
+++ b/BioFormatsSplit/imagej-bioformats-vncstartup
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+unset SESSION_MANAGER
+unset DBUS_SESSION_BUS_ADDRESS
+
+if [ -z "$IMAGEJ_MACRO_FILE" ]; then
+    echo "ERROR:  no IMAGEJ_MACRO_FILE provided" 1>&2
+    exit 1
+fi
+if [ ! -f "$IMAGEJ_MACRO_FILE" ]; then
+    echo "ERROR:  IMAGEJ_MACRO_FILE=$IMAGEJ_MACRO_FILE: file does not exist" 1>&2
+    exit 2
+fi
+
+IMAGEJ_ARGV=("$IMAGEJ_MACRO_FILE")
+if [ -n "$IMAGEJ_MACRO_DATADIR" ]; then
+    IMAGEJ_ARGV+=("$IMAGEJ_MACRO_DATADIR")
+fi
+
+if [ -z "$IMAGEJ_MACRO_LOGFILE" ]; then
+    exec ImageJ-linux64 -batch "${IMAGEJ_ARGV[@]}"
+else
+    exec ImageJ-linux64 -batch "${IMAGEJ_ARGV[@]}" > "$IMAGEJ_MACRO_LOGFILE" 2>&1
+fi
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.1.0]
+### Added
+- Wrapper script for running ImageJ BioFormats import of Zeiss CZI images and export to TIFF
+  - "Windowless" mode does not work -- an X11 display is required, so run the script in a VNC session
+
 ## [v1.0.0]
 ### Added
 - Infrastructure added to project for make-based compilation and installation of the software on Linux

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ all:
 	$(MAKE) -C SkeletonConnection
 	$(MAKE) -C SurfaceEstimation
 	$(MAKE) -C ThresholdAndSkeletonize
+	$(MAKE) -C BioFormatsSplit
 
 clean:
 	$(MAKE) -C Segmentation clean
@@ -15,6 +16,7 @@ clean:
 	$(MAKE) -C SkeletonConnection clean
 	$(MAKE) -C SurfaceEstimation clean
 	$(MAKE) -C ThresholdAndSkeletonize clean
+	$(MAKE) -C BioFormatsSplit clean
 
 install: $(PREFIX)
 	$(MAKE) -C Segmentation install
@@ -22,5 +24,6 @@ install: $(PREFIX)
 	$(MAKE) -C SkeletonConnection install
 	$(MAKE) -C SurfaceEstimation install
 	$(MAKE) -C ThresholdAndSkeletonize install
+	$(MAKE) -C BioFormatsSplit install
 
 include Makefile.rules.post


### PR DESCRIPTION
Empirical testing shows that the ImageJ BioFormats plugin cannot function in an environment lacking an X11 display.  A wrapper script was created that executes ImageJ inside a VNC session.  The wrapper reads a Zeiss CZI file and exports all frames to separate TIFF images.